### PR TITLE
Load OPA Policy by kube-mgmt

### DIFF
--- a/k8s/identityd.yaml
+++ b/k8s/identityd.yaml
@@ -21,13 +21,10 @@ spec:
         image: openpolicyagent/opa:0.14.0
         imagePullPolicy: IfNotPresent
         name: opa
-        volumeMounts:
-        - mountPath: /config
-          name: config
-          readOnly: true
       - args:
         - --opa-url=http://127.0.0.1:8181/v1
         - --enable-policies=true
+        - --policies=default
         - --replicate-path=kubernetes
         - --replicate=v1/pods
         image: openpolicyagent/kube-mgmt:0.10
@@ -45,10 +42,6 @@ spec:
                   echo {\"cert\"":" \"$(cat /tmp/api-pubkey.pem)\"}  > /tmp/cert.json &&
                   curl "localhost:8181/v1/data/kubernetes/keys" -X PUT -d @/tmp/cert.json
       serviceAccountName: identityd
-      volumes:
-      - configMap:
-          name: identity-validation.rego
-        name: config
 
 ---
 apiVersion: v1

--- a/k8s/rbac.yaml
+++ b/k8s/rbac.yaml
@@ -12,6 +12,16 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews

--- a/k8s/rbac.yaml
+++ b/k8s/rbac.yaml
@@ -19,7 +19,6 @@ rules:
   - get
   - list
   - watch
-  - update
   - patch
 - apiGroups:
   - authentication.k8s.io


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

----

In previously PR(yahoo/k8s-athenz-identity/pull/18), I submitted to make sure OPA read the Policy.
However, in this PR, I'll revert the previous method to load policy by kube-mgmt, according to the kube-mgmt's README. This is more k8s way and load policy dynamically.
Also eliminates the following RBAC errors in mgmt container.

```
github.com/open-policy-agent/kube-mgmt/pkg/configmap/configmap.go:159: Failed to list *v1.ConfigMap: unknown (get configmaps)
```
