### PR TITLE
delete unnecessary error assignment

### DIFF
--- a/cmd/athenz-sia/main.go
+++ b/cmd/athenz-sia/main.go
@@ -71,8 +71,7 @@ func parseFlags(program string, args []string) (*identity.IdentityConfig, error)
 	err := f.Parse(args)
 	if err != nil {
 		if err == flag.ErrHelp {
-			err = errEarlyExit
-			return nil, err
+			return nil, errEarlyExit
 		}
 		log.InitLogger(filepath.Join(logDir, fmt.Sprintf("%s.%s.log", serviceName, logLevel)), logLevel, true)
 		return nil, err


### PR DESCRIPTION
This PR contains code refactoring.
I refactored because there was an unnecessary error assignment.
I thought it would be simpler to return an error without having to reassign the error.

the following is  code example.
https://play.golang.org/p/KgHyZGHyLgL


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


cc: @prabushyam 